### PR TITLE
Fix gist fallback shared repository routing

### DIFF
--- a/.changeset/shared-repository-fallback.md
+++ b/.changeset/shared-repository-fallback.md
@@ -1,0 +1,5 @@
+---
+'gh-upload-log': patch
+---
+
+Route repository fallbacks through shared log repositories by default.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-12T07:07:28.238Z for PR creation at branch issue-31-28ec68d7ecc4 for issue https://github.com/link-foundation/gh-upload-log/issues/31

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-12T07:07:28.238Z for PR creation at branch issue-31-28ec68d7ecc4 for issue https://github.com/link-foundation/gh-upload-log/issues/31

--- a/.lenv.example
+++ b/.lenv.example
@@ -19,7 +19,7 @@
 # Force upload only as GitHub Repository (default: false)
 # GH_UPLOAD_LOG_ONLY_REPOSITORY: false
 
-# Use shared private-logs/public-logs repositories for large files (default: true)
+# Use shared private-logs/public-logs repositories for repository-mode uploads (default: true)
 # GH_UPLOAD_LOG_SHARED_REPOSITORY: true
 
 # Enable dry run mode by default (default: false)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A smart tool to upload log files to GitHub as Gists or Repositories
 ## Features
 
 - **Automatic strategy selection**: Chooses between Gist and Repository based on file size
-- **Shared large-log repositories by default**: Large files go into `private-logs` or `public-logs`
-- **Duplicate protection**: Re-uploading the same large log path reuses the existing shared repository folder
+- **Shared repository uploads by default**: Repository-mode files go into `private-logs` or `public-logs`
+- **Duplicate protection**: Re-uploading the same repository-mode log path reuses the existing shared repository folder
 - **Smart file splitting**: Automatically splits large files into manageable chunks
 - **Public/Private control**: Upload as public or private (default: private)
 - **Flexible configuration**: CLI arguments, environment variables, or `.lenv` files using [Links Notation](https://github.com/link-foundation/links-notation)
@@ -108,7 +108,7 @@ gh-upload-log /var/log/app.log
 - `GH_UPLOAD_LOG_AUTO` - Enable automatic strategy selection (default: true)
 - `GH_UPLOAD_LOG_ONLY_GIST` - Force gist uploads only (default: false)
 - `GH_UPLOAD_LOG_ONLY_REPOSITORY` - Force repository uploads only (default: false)
-- `GH_UPLOAD_LOG_SHARED_REPOSITORY` - Use shared `private-logs` / `public-logs` repositories for large files (default: true)
+- `GH_UPLOAD_LOG_SHARED_REPOSITORY` - Use shared `private-logs` / `public-logs` repositories for repository-mode uploads (default: true)
 - `GH_UPLOAD_LOG_DRY_MODE` - Enable dry run mode (default: false)
 - `GH_UPLOAD_LOG_DESCRIPTION` - Default description for uploads
 - `GH_UPLOAD_LOG_VERBOSE` - Enable verbose output (default: false)
@@ -141,7 +141,7 @@ Options:
   --auto               Automatically choose upload strategy (default: true)
   --only-gist          Upload only as GitHub Gist (disables auto mode)
   --only-repository    Upload only as GitHub Repository (disables auto mode)
-  --shared-repository  Upload large repository-mode logs into shared
+  --shared-repository  Upload repository-mode logs into shared
                        private-logs/public-logs repositories (default: true)
   --dry-mode, --dry    Dry run - show what would be done without uploading
   --description, -d    Description for the upload
@@ -165,7 +165,7 @@ gh-upload-log ./error.log --only-gist
 # Upload only as repository
 gh-upload-log ./large.log --only-repository --public
 
-# Use the legacy dedicated repository mode for a large file
+# Use the legacy dedicated repository mode
 gh-upload-log ./large.log --only-repository --no-shared-repository
 
 # Dry run mode - see what would happen
@@ -226,7 +226,7 @@ Main function to upload a log file. Automatically determines the best strategy.
   - `auto` (boolean): Automatically choose strategy (default: true)
   - `onlyGist` (boolean): Upload only as gist (disables auto mode)
   - `onlyRepository` (boolean): Upload only as repository (disables auto mode)
-  - `useSharedRepository` (boolean): Use shared `private-logs` / `public-logs` repositories for files larger than 25MB (default: true)
+  - `useSharedRepository` (boolean): Use shared `private-logs` / `public-logs` repositories for repository-mode uploads (default: true)
   - `dryMode` (boolean): Dry run mode - don't actually upload
   - `description` (string): Description for the upload
   - `verbose` (boolean): Enable verbose logging (default: false)
@@ -243,7 +243,7 @@ Main function to upload a log file. Automatically determines the best strategy.
   fileCount?: number,
   fileName?: string,           // For gists
   repositoryName?: string,     // For repos
-  repositoryPath?: string,     // Shared repository folder for large files
+  repositoryPath?: string,     // Shared repository folder for repository-mode uploads
   deduplicated?: boolean,      // True when an existing shared-repo upload was reused
   dryMode?: boolean            // Set to true in dry mode
 }
@@ -266,7 +266,7 @@ Upload a file as a GitHub Gist.
 
 #### `uploadAsRepo(options)`
 
-Upload a file as a GitHub Repository. Files larger than 25MB use the shared
+Upload a file as a GitHub Repository. Repository-mode uploads use the shared
 `private-logs` / `public-logs` repositories by default. Set
 `useSharedRepository: false` to keep the legacy dedicated-repository behavior.
 
@@ -275,7 +275,7 @@ Upload a file as a GitHub Repository. Files larger than 25MB use the shared
 - `options` (object):
   - `filePath` (string, **required**): Path to the file
   - `isPublic` (boolean): Make repo public (default: false)
-  - `useSharedRepository` (boolean): Use shared repositories for large files (default: true)
+  - `useSharedRepository` (boolean): Use shared repositories for repository-mode uploads (default: true)
   - `description` (string): Repository description
   - `verbose` (boolean): Enable verbose logging (default: false)
   - `logger` (object): Custom logging target (default: console)
@@ -341,11 +341,12 @@ Examples:
    - Single file upload
    - Fast and efficient
    - Viewable directly in browser
+   - If gist creation fails in auto mode, repository fallback uses the shared `private-logs` or `public-logs` repository by default
 
 2. **Files >25MB**: Uploaded as GitHub Repository
    - By default, uploads go into the shared `private-logs` or `public-logs` repository
    - The old dedicated-repository flow is still available with `--no-shared-repository` or `useSharedRepository: false`
-   - Re-uploading the same large-file path reuses the existing shared repository folder instead of pushing a duplicate
+   - Re-uploading the same repository path reuses the existing shared repository folder instead of pushing a duplicate
 
 3. **Files >100MB**: Uploaded as a chunked GitHub Repository folder
    - File is split into 100MB chunks

--- a/src/cli.js
+++ b/src/cli.js
@@ -52,7 +52,7 @@ const config = makeConfig({
       .option('shared-repository', {
         type: 'boolean',
         description:
-          'Upload large repository-mode logs into shared private-logs/public-logs repositories (default: true)',
+          'Upload repository-mode logs into shared private-logs/public-logs repositories (default: true)',
         default: getenv('GH_UPLOAD_LOG_SHARED_REPOSITORY', true),
       })
       .option('dry-mode', {

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ export async function uploadAsGist(options = {}) {
  * @param {boolean} options.auto - Automatically choose strategy (default: true)
  * @param {boolean} options.onlyGist - Upload only as gist (disables auto mode)
  * @param {boolean} options.onlyRepository - Upload only as repository (disables auto mode)
- * @param {boolean} options.useSharedRepository - Use shared log repositories for large files (default: true)
+ * @param {boolean} options.useSharedRepository - Use shared log repositories for repository-mode uploads (default: true)
  * @param {boolean} options.dryMode - Dry run mode - don't actually upload
  * @param {string} options.description - Description for the upload
  * @param {boolean} options.verbose - Enable verbose logging (default: false)

--- a/src/repository-upload.js
+++ b/src/repository-upload.js
@@ -14,7 +14,6 @@ import {
   getCommandExitCode,
   getCommandStream,
   getFileSize,
-  GITHUB_GIST_FILE_LIMIT,
   GITHUB_REPO_CHUNK_SIZE,
   isENOSPC,
   isRepositoryNameConflict,
@@ -41,10 +40,10 @@ function isMissingRemoteRefError(errorText = '') {
 }
 
 export function shouldUseSharedRepositoryMode(
-  filePath,
+  _filePath,
   useSharedRepository = true
 ) {
-  return useSharedRepository && getFileSize(filePath) > GITHUB_GIST_FILE_LIMIT;
+  return useSharedRepository;
 }
 
 export function getSharedRepositoryName(isPublic = false) {
@@ -552,13 +551,13 @@ async function uploadAsSharedRepo(options = {}) {
 /**
  * Upload a file as a GitHub repository (with splitting if needed)
  *
- * Large files use the shared visibility repositories (`private-logs` or
+ * Repository-mode uploads use the shared visibility repositories (`private-logs` or
  * `public-logs`) by default. The legacy dedicated-repository mode remains
  * available through the `useSharedRepository` option.
  *
  * @param {Object} options - Upload options
  * @param {string} options.filePath - Path to the file to upload
- * @param {boolean} options.useSharedRepository - Use shared log repositories for large files (default: true)
+ * @param {boolean} options.useSharedRepository - Use shared log repositories for repository-mode uploads (default: true)
  * @returns {Promise<Object>} Repository information including URL
  */
 export function uploadAsRepo(options = {}) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -144,7 +144,7 @@ test('CLI with --only-repository flag', async () => {
   );
 });
 
-test('CLI repository dry mode uses shared repositories for large files by default', async () => {
+test('CLI repository dry mode uses shared repositories by default', async () => {
   const result = await runCLI([
     largeCliRepoFile,
     '--only-repository',
@@ -154,7 +154,7 @@ test('CLI repository dry mode uses shared repositories for large files by defaul
   assert.equal(result.code, 0, 'Should exit with code 0');
   assert.ok(
     result.output.includes('Repository: private-logs'),
-    'Large repository-mode uploads should default to the shared private repository'
+    'Repository-mode uploads should default to the shared private repository'
   );
   assert.ok(
     result.output.includes('Path: log-test-fixtures-cli-shared-large'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -411,6 +411,7 @@ test('uploadLog - surfaces gh repo create failures instead of reporting success'
     await uploadLog({
       filePath: collisionFile,
       onlyRepository: true,
+      useSharedRepository: false,
       isPublic: true,
       commandStreamFactory: () => fakeCommandStream,
     });
@@ -494,6 +495,7 @@ test('uploadLog - retries with a unique repository name after a collision', asyn
   const result = await uploadLog({
     filePath: retryFile,
     onlyRepository: true,
+    useSharedRepository: false,
     isPublic: true,
     commandStreamFactory: () => fakeCommandStream,
   });
@@ -791,6 +793,139 @@ test('uploadLog - keeps dedicated repository mode available when shared mode is 
       )
     ),
     'Legacy repository mode should still create a dedicated repository'
+  );
+});
+
+test('uploadLog - gist fallback uses shared repositories for small files by default', async () => {
+  const fallbackFile = path.join('test', 'fixtures', 'auto-fallback-small.log');
+  fs.writeFileSync(fallbackFile, 'fallback to shared repository\n');
+
+  const sharedFolder = 'log-test-fixtures-auto-fallback-small';
+  const commands = [];
+  let folderLookupCalls = 0;
+
+  const fakeCommandStream = createFakeCommandStream((command) => {
+    commands.push(command);
+
+    if (command.startsWith('gh gist create ')) {
+      return createCommandResult({
+        code: 1,
+        stderr: 'secondary rate limit\n',
+      });
+    }
+    if (command === 'gh api user --jq .login') {
+      return createCommandResult({ stdout: 'test-user\n' });
+    }
+    if (
+      command ===
+      'gh api repos/test-user/public-logs --jq {"defaultBranch": .default_branch, "visibility": .visibility}'
+    ) {
+      return createCommandResult({
+        stdout: '{"defaultBranch":"main","visibility":"public"}\n',
+      });
+    }
+    if (
+      command ===
+      `gh api repos/test-user/public-logs/contents/${sharedFolder} --jq map({name: .name, download_url: .download_url})`
+    ) {
+      folderLookupCalls += 1;
+
+      if (folderLookupCalls === 1) {
+        return createCommandResult({
+          code: 1,
+          stderr: 'gh: Not Found (HTTP 404)\n',
+        });
+      }
+
+      return createCommandResult({
+        stdout: JSON.stringify([
+          {
+            name: 'test-fixtures-auto-fallback-small.log',
+            download_url:
+              'https://raw.githubusercontent.com/test-user/public-logs/main/log-test-fixtures-auto-fallback-small/test-fixtures-auto-fallback-small.log',
+          },
+        ]),
+      });
+    }
+    if (command.includes('git init')) {
+      return createCommandResult();
+    }
+    if (command.includes('git branch -m main')) {
+      return createCommandResult();
+    }
+    if (
+      command.includes(
+        'git remote add origin https://github.com/test-user/public-logs.git'
+      )
+    ) {
+      return createCommandResult();
+    }
+    if (command.includes('git sparse-checkout init --no-cone')) {
+      return createCommandResult();
+    }
+    if (command.includes(`git sparse-checkout add ${sharedFolder}`)) {
+      return createCommandResult();
+    }
+    if (
+      command.includes('git fetch --depth 1 --filter=blob:none origin main')
+    ) {
+      return createCommandResult();
+    }
+    if (command.includes('git checkout -B main FETCH_HEAD')) {
+      return createCommandResult();
+    }
+    if (command.includes('git add .')) {
+      return createCommandResult();
+    }
+    if (command.includes('git commit -m "Add log file"')) {
+      return createCommandResult();
+    }
+    if (command.includes('git push -u origin main')) {
+      return createCommandResult();
+    }
+
+    return createCommandResult();
+  });
+
+  const result = await uploadLog({
+    filePath: fallbackFile,
+    isPublic: true,
+    description: 'fallback',
+    commandStreamFactory: () => fakeCommandStream,
+  });
+
+  assert.equal(result.type, 'repo');
+  assert.equal(result.repositoryName, 'public-logs');
+  assert.equal(result.repositoryPath, sharedFolder);
+  assert.equal(result.isPublic, true);
+  assert.equal(result.fileCount, 1);
+  assert.equal(
+    result.url,
+    'https://github.com/test-user/public-logs/tree/main/log-test-fixtures-auto-fallback-small'
+  );
+  assert.equal(
+    result.rawUrl,
+    'https://raw.githubusercontent.com/test-user/public-logs/main/log-test-fixtures-auto-fallback-small/test-fixtures-auto-fallback-small.log'
+  );
+  assert.ok(
+    commands.some((command) => command.startsWith('gh gist create ')),
+    'Auto mode should attempt gist upload first for small files'
+  );
+  assert.ok(
+    commands.some((command) =>
+      command.includes(
+        'git remote add origin https://github.com/test-user/public-logs.git'
+      )
+    ),
+    'Fallback should configure the shared public repository remote'
+  );
+  assert.ok(
+    !commands.some((command) =>
+      command.includes(
+        'gh repo create log-test-fixtures-auto-fallback-small --public --source=. --push'
+      )
+    ),
+    'Fallback should not create a dedicated per-log repository by default'
   );
 });
 


### PR DESCRIPTION
Fixes #31

## Summary
- Route repository-mode uploads to shared `private-logs` / `public-logs` repositories whenever `useSharedRepository` is enabled, regardless of the original file size.
- Keep dedicated per-log repositories available only when callers pass `useSharedRepository: false` or `--no-shared-repository`.
- Update CLI/API docs and config example wording from “large files” to “repository-mode uploads”.
- Add a patch changeset.

## Reproduction
A file under the gist limit uses gist first in auto mode. If `gh gist create` fails, the old fallback path entered repository mode but skipped shared repositories because routing was gated by `fileSize > GITHUB_GIST_FILE_LIMIT`, producing a dedicated `log-*` repository.

## Tests
- Added `uploadLog - gist fallback uses shared repositories for small files by default`, which simulates a small public log, a gist secondary-rate-limit failure, and verifies fallback writes to `public-logs/<repositoryPath>` without creating a dedicated repository.
- Updated dedicated repository collision tests to opt into legacy mode with `useSharedRepository: false`.

## Verification
- `bun run check`
- `bun test`
